### PR TITLE
initial work on allowing builders to use git to fetch Twisted code.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -27,7 +27,7 @@ del expanduser, dirname, sys
 from buildbot.changes.pb import PBChangeSource
 from buildbot.schedulers.timed import Nightly
 from buildbot.schedulers import forcesched
-from buildbot.steps.source import SVN, Git
+from buildbot.steps.source import SVN
 from buildbot.process.factory import s
 from buildbot.status import words, client, mail
 from buildbot.status.web.auth import BasicAuth
@@ -58,6 +58,7 @@ from twisted_factories import (
     )
 
 from txbuildbot.bzrsvn import BzrSvn
+from txbuildbot.git import TwistedGit
 
 from txbuildbot.web import TwistedWebStatus
 from txbuildbot.scheduler import TwistedScheduler
@@ -110,22 +111,6 @@ c['change_source'].append(source)
 
 
 ## configure the builders
-
-class TwistedGit(Git):
-    """
-    This should be *very* temporary; it's to support people trying to force
-    builds against /branches/foo and letting it work on the git builders.
-    People should start switching to just "foo", but while we have both
-    SVN-based and git-based builders going it'll be impossible to force
-    builds on all bots at the same time with the same command.
-    """
-
-    def startVC(self, branch, revision, patch):
-        cutoff = "/branches/"
-        if branch.startswith(cutoff):
-            branch = branch[len(cutoff):]
-        return Git.startVC(self, branch, revision, patch)
-
 
 # for build-on-branch
 baseURL = "svn://svn.twistedmatrix.com/svn/Twisted/"

--- a/master/txbuildbot/git.py
+++ b/master/txbuildbot/git.py
@@ -1,0 +1,21 @@
+from buildbot.steps.source.git import Git
+
+
+class TwistedGit(Git):
+    """
+    This should be *very* temporary; it's to support people trying to force
+    builds against /branches/foo and letting it work on the git builders.
+    People should start switching to just "foo", but while we have both
+    SVN-based and git-based builders going it'll be impossible to force
+    builds on all bots at the same time with the same command.
+    """
+
+    def startVC(self, branch, revision, patch):
+        """
+        If a branch name starts with /branches/, cut it off before referring
+        to it in git commands.
+        """
+        cutoff = "/branches/"
+        if branch.startswith(cutoff):
+            branch = branch[len(cutoff):]
+        return Git.startVC(self, branch, revision, patch)


### PR DESCRIPTION
This change doesn't actually make any builders use git, just inserts a bit of compatibility and declares the step.
