### PR TITLE
use the git_revision property of Changes to know the git rev

### DIFF
--- a/master/txbuildbot/git.py
+++ b/master/txbuildbot/git.py
@@ -3,20 +3,24 @@ from buildbot.steps.source.git import Git
 
 class TwistedGit(Git):
     """
-    This should be *very* temporary; it's to support people trying to force
-    builds against /branches/foo and letting it work on the git builders.
-    People should start switching to just "foo", but while we have both
-    SVN-based and git-based builders going it'll be impossible to force
-    builds on all bots at the same time with the same command.
+    Temporary support for the transitionary stage between SVN and Git.
     """
 
     def startVC(self, branch, revision, patch):
         """
-        If a branch name starts with /branches/, cut it off before referring
-        to it in git commands.
+        * If a branch name starts with /branches/, cut it off before referring
+          to it in git commands.
+        * If a "git_revision" property is provided in the Change, use it
+          instead of the base revision number.
         """
         for cutoff in ['/branches/', 'branches/']:
             if branch.startswith(cutoff):
                 branch = branch[len(cutoff):]
                 break
+        id = self.getRepository()
+        s = self.build.getSourceStamp(id)
+        if s.changes:
+            latest_properties = s.changes[-1].properties
+            if "git_revision" in latest_properties:
+                revision = latest_properties["git_revision"]
         return Git.startVC(self, branch, revision, patch)


### PR DESCRIPTION
honor a "git_revision" change property to know which git revision to test.

An associated change in svn_buildbot.py includes this property the addChange call.

I've tested this with a local setup created with briad, using the post-commit svn_buildbot.py script (very slightly hacked since I didn't have a local copy of the svn repo). I've also tested builds through the web (which won't have the git_revision property, and just run the HEAD of a branch).
