### PR TITLE
Support a handful of builders that have been green a lot recently.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -441,8 +441,12 @@ builders.append({
         'slavenames': fedora19_slaves,
         'factory': TwistedReactorsBuildFactory(
             git_update, python="python", reactors=["select", "poll", "epoll", "glib2"]),
-        'category': 'unsupported'})
+        'category': 'supported'})
 
+_supportedCombos = {
+    "debian6-x86_64-py2.6", "debian6-x86_64-py2.6-glib",
+    "ubuntu-12.04-x86_64-py2.7", "ubuntu-12.04-x86_64-py2.7-glib",
+    }
 for name, reactors in [("", ["select", "poll", "epoll"]),
                        ("-glib", ["glib2"])
                        ]:
@@ -452,13 +456,19 @@ for name, reactors in [("", ["select", "poll", "epoll"]),
                                    ('ubuntu-12.10', 'py2.7', ubuntu12_10_slaves),
                                    ('ubuntu-13.04', 'py2.7', ubuntu13_04_slaves),
                                    ]:
+        category = 'supported'
+        builderName = '%s-x86_64-%s%s' % (distro, python, name)
+        if builderName not in _supportedCombos:
+            category = 'un' + category
+
         builders.append({
-                'name': '%s-x86_64-%s%s' % (distro, python, name),
-                'builddir': '%s-x86_64-%s%s' % (distro, python, name),
+                'name': builderName,
+                'builddir': builderName,
                 'slavenames': slaves,
                 'factory': TwistedReactorsBuildFactory(
                     git_update, python="python", reactors=reactors),
-                'category': 'unsupported'})
+                'category': category,
+                })
 
 builders.append({
           'name': 'natty64-py2.6-wx',


### PR DESCRIPTION
These builders have a long history of being green.  Historically, that's been sufficient for declaring a platform supported.

Any reason not to call any of these supported now?
