### PR TITLE
Add builder which execute python command in an virtualenv in Linux/Unix.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -53,6 +53,7 @@ from twisted_factories import (
     PyFlakesBuildFactory,
     )
 
+from txbuildbot.bzrsvn import BzrSvn
 from txbuildbot.git import TwistedGit, MergeForward
 
 from txbuildbot.web import TwistedWebStatus

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -53,7 +53,6 @@ from twisted_factories import (
     PyFlakesBuildFactory,
     )
 
-from txbuildbot.bzrsvn import BzrSvn
 from txbuildbot.git import TwistedGit, MergeForward
 
 from txbuildbot.web import TwistedWebStatus

--- a/master/twisted_factories.py
+++ b/master/twisted_factories.py
@@ -98,18 +98,15 @@ class TwistedBaseFactory(BuildFactory):
         self.trialTests = trialTests
 
         if virtualenv:
-            # When reason = clean we remove the virtualenv folder.
-            self.addStep(
-                shell.ShellCommand,
-                name='clean venv - only when reason=clean',
-                command=['rm', '-rf', self._virtualEnvPath],
-                doStepIf=lambda step: step.build.getProperties()['reason'] == 'clean'
-                )
-            # Create the virtualenv.
+            # Each time we create a new virtualenv as latest pip can build
+            # wheels on the fly and install them from user's cache.
             self.addStep(
                 shell.ShellCommand,
                 command=[
-                    'virtualenv', '-p', self.python[0], self._virtualEnvPath],
+                    'virtualenv', '--clear',
+                    '-p', self.python[0],
+                    self._virtualEnvPath,
+                    ],
                 )
 
         self.addStep(


### PR DESCRIPTION
Problem
======

A single slave might run multiple builders and each builder might have different (maybe conflicting) python dependencies.

Changes
=======

To solve this each builder will create its own virtualenv.

Initial version was with virtualenv installed inside the source folder.

I went for virtualenv outside of the source code so that it is persisted between builds... as some pip installs might take a long time

Custom builders can run `pip install` to install various dependencies.

I have migrated the twistedchecker builder to the virtuelenv builder as a test. This should also help fix https://github.com/twisted-infra/braid/issues/87

I have only tested this on my vagrant VM on Linux.

Future considerations
=================

Right now it only works on Unix/Linux as on Windows .bin folder is ,Scripts. We can add windows support in a separate ticket.

It will run virtualenv command at each run, even if the virtualenv already exists.

How to test
=========

Apply the changes to the buildmaster and trigger a build on twistedchecker

Trigger a test with reason as `clean` and the builder will clean the venv folder first.
