### PR TITLE
Make py3 warnings builder supported.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -197,7 +197,7 @@ builders.append ({
     'builddir': 'python-3k-warnings',
     'factory': FullTwistedBuildFactory(git_update,
                                        python=["python2.7", "-3"]),
-    'category': 'unsupported'})
+    'category': 'supported'})
 
 
 builders.append({


### PR DESCRIPTION
Problem
=======

py3 warnings builder was fixed in https://twistedmatrix.com/trac/ticket/7931 and we should make it official ASAP to prevent being broken again.


Changes
=======

change category to supported


How to test
=========

@hawkowl please take a look at the changes and apply them in production.

I don't have permission to deploy them in production,

Thanks!